### PR TITLE
Update to warp 0.3 and tokio 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,12 @@ documentation = "https://docs.rs/static_dir"
 keywords = ["warp", "web", "static", "assets", "include"]
 
 [dependencies]
-warp = "0.2"
+warp = "0.3"
 log = "0.4"
-include_dir = "0.5"
-proc-macro-hack = "0.5"
-urlencoding = "1.0"
+include_dir = { version = "0.6", default-features = false }
+urlencoding = "1.1"
 headers = "0.3"
-hyper = "0.13"
+hyper = "0.14"
 http = "0.2"
 once_cell = "1.3"
 mime_guess = "2.0"
-futures = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 //! A crate for embedding static assets into warp webservers.
 #![warn(rust_2018_idioms, missing_docs)]
 
-use futures::future::ready;
 use headers::{
     AcceptRanges, ContentLength, ContentRange, ContentType, HeaderMapExt, IfModifiedSince, IfRange,
     IfUnmodifiedSince, LastModified, Range,
@@ -9,7 +8,7 @@ use headers::{
 use http::{HeaderMap, StatusCode};
 use hyper::Body;
 use once_cell::sync::Lazy;
-use proc_macro_hack::proc_macro_hack;
+use std::future::ready;
 use std::{
     path::{Path, PathBuf},
     time::SystemTime,
@@ -23,7 +22,6 @@ use warp::{
 };
 
 #[doc(hidden)]
-#[proc_macro_hack]
 pub use include_dir::include_dir;
 
 #[doc(hidden)]
@@ -70,7 +68,6 @@ macro_rules! static_dir {
     }};
 }
 
-#[doc(hidden)]
 /// Creates a [Filter][warp::Filter] that serves an included directory.
 ///
 /// See the documentation of [static_dir] for details.
@@ -214,8 +211,7 @@ fn reply_range(
     (s, e): (u64, u64),
     path: &Path,
     last_mod: LastModified,
-) -> Response
-{
+) -> Response {
     let len = e - s;
     let buf = &buf[s as usize..e as usize];
 


### PR DESCRIPTION
I also removed the `doc(hidden)` on `dir()`, since I figure that's something that may be worth having as part of the API. I could remove that if you don't think that's a good idea, though.