### PR TITLE
update dependencies and rust edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "static_dir"
 version = "0.2.0"
 authors = ["nytopop <ericizoita@gmail.com>"]
-edition = "2018"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "A crate for embedding static assets into warp webservers."
 homepage = "https://github.com/nytopop/static_dir"
@@ -11,12 +11,12 @@ documentation = "https://docs.rs/static_dir"
 keywords = ["warp", "web", "static", "assets", "include"]
 
 [dependencies]
-warp = "0.3"
+warp = "0.4"
 log = "0.4"
 include_dir = { version = "0.6", default-features = false }
-urlencoding = "1.1"
-headers = "0.3"
-hyper = "0.14"
-http = "0.2"
+urlencoding = "2"
+headers = "0.4"
+hyper = "1"
+http = "1"
 once_cell = "1.3"
 mime_guess = "2.0"


### PR DESCRIPTION
I tried to also update `include_dir`, but I failed:

The `macro_rules` somehow creates a `Group` in the AST which leads to the error `This macro only accepts a single, non-empty string argument`.

AST of argument to `include_dir!()` of `static_dir!("../public")` with `include_dir` updated to 0.7:

```
[Group { delimiter: None, stream: TokenStream [Literal { kind: Str, symbol: "../public", suffix: None, span: #0 bytes(138294..138305) }], span: #1520 bytes(4599641..4599646) }]
```